### PR TITLE
Update node-abi to 2.1.1 for Electron 1.8.0 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "github-from-package": "0.0.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
-    "node-abi": "^2.0.0",
+    "node-abi": "^2.1.1",
     "noop-logger": "^0.1.1",
     "npmlog": "^4.0.1",
     "os-homedir": "^1.0.1",


### PR DESCRIPTION
Otherwise "Could not detect abi for version 1.8.0 and runtime electron.  Updating "node-abi" might help solve this issue if it is a new release of electron"

Please publish new version after merge if possible.